### PR TITLE
Create .npmignore

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -22,3 +22,6 @@ node_modules
 
 # TypeScript config
 tsconfig.json
+
+# TSD configuration
+tsd.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,5 @@
-# TypeScript src folder
-src
+# TypeScript files
+src/**/*.ts
 
 # Tests
 src/**/*.spec.js

--- a/.npmignore
+++ b/.npmignore
@@ -28,3 +28,6 @@ tsd.json
 
 # TypeScript formatter
 tsfmt.json
+
+# TypeScript linter
+tslint.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,5 +1,5 @@
 # TypeScript files
-src/**/*.ts
+*.ts
 
 # TypeScript - JavaScript mappings
 *.js.map

--- a/.npmignore
+++ b/.npmignore
@@ -12,3 +12,7 @@ typings
 
 # .gitignore
 .gitignore
+
+# Karma configuration
+karma.conf.js
+karma.conf.json

--- a/.npmignore
+++ b/.npmignore
@@ -9,3 +9,6 @@ typings
 
 # ESLint config
 .eslintrc
+
+# .gitignore
+.gitignore

--- a/.npmignore
+++ b/.npmignore
@@ -3,3 +3,6 @@ src/**/*.ts
 
 # Tests
 src/**/*.spec.js
+
+# TSD typings
+typings

--- a/.npmignore
+++ b/.npmignore
@@ -16,3 +16,6 @@ typings
 # Karma configuration
 karma.conf.js
 karma.conf.json
+
+# Node modules (npm will install these for us properly)
+node_modules

--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,5 @@
 # TypeScript src folder
 src
+
+# Tests
+build/**/*.spec.js

--- a/.npmignore
+++ b/.npmignore
@@ -19,3 +19,6 @@ karma.conf.json
 
 # Node modules (npm will install these for us properly)
 node_modules
+
+# TypeScript config
+tsconfig.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,2 @@
+# TypeScript src folder
+src

--- a/.npmignore
+++ b/.npmignore
@@ -25,3 +25,6 @@ tsconfig.json
 
 # TSD configuration
 tsd.json
+
+# TypeScript formatter
+tsfmt.json

--- a/.npmignore
+++ b/.npmignore
@@ -1,6 +1,9 @@
 # TypeScript files
 src/**/*.ts
 
+# TypeScript - JavaScript mappings
+*.js.map
+
 # Tests
 src/**/*.spec.js
 

--- a/.npmignore
+++ b/.npmignore
@@ -6,3 +6,6 @@ src/**/*.spec.js
 
 # TSD typings
 typings
+
+# ESLint config
+.eslintrc

--- a/.npmignore
+++ b/.npmignore
@@ -2,4 +2,4 @@
 src
 
 # Tests
-build/**/*.spec.js
+src/**/*.spec.js


### PR DESCRIPTION
This file tells npm which files not to upload, which can significantly reduce the size of the npm distribution.