### PR TITLE
Don't ignore karma.conf.js from git updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,6 @@ typings
 
 *.js
 *.js.map
+
+# Don't ignore karma.conf.js, even though it is a JS file
+!karma.conf.js


### PR DESCRIPTION
`karma.conf.js` is currently covered by the `*.js` line in the `.gitignore` file.

This PR excludes `karma.conf.js` from that file so it can still be tracked with git.