### PR TITLE
handle blur targets

### DIFF
--- a/src/EventDelegate/index.ts
+++ b/src/EventDelegate/index.ts
@@ -12,8 +12,9 @@ export class EventDelegate {
 
   public init(): void {
     this._setEventListener(new Trigger(TriggerType[TriggerType['CLICK']]), this.onClick);
-    this._setEventListener(new Trigger(TriggerType[TriggerType['HOVER']]), this.onHover);
+    this._setEventListener(new Trigger(TriggerType[TriggerType['BLUR']]), this.onBlur);
     this._setEventListener(new Trigger(TriggerType[TriggerType['FOCUS']]), this.onFocus);
+    this._setEventListener(new Trigger(TriggerType[TriggerType['HOVER']]), this.onHover);
     this._setEventListener(new Trigger(TriggerType[TriggerType['MANUAL']]), this.onManual);
     this._setEventListener(new Trigger(TriggerType[TriggerType['MOUSEOUT']]), this.onMouseOut);
     popEngine.listenForScroll();
@@ -61,6 +62,16 @@ export class EventDelegate {
       let pop = popEngine.getPopFromGroupId(groupId);
       timeoutManager.maybeClearTimeout(timeoutManager.getTimeouts().timeToHoverOnPop, groupId);
       this._clearParentPops(pop);
+    }
+  }
+
+  public onBlur(e: Event): void {
+    let t: string = TriggerEventType.triggerEventTypeToTriggerType('focusin');
+    let trigger: Trigger = new Trigger(t);
+    let target: Element = <Element>closest(e.target, '[popgun]', true);
+
+    if (popEngine.isPopForTrigger(target, trigger)) {
+      popEngine.hidePop(target, false);
     }
   }
 
@@ -131,7 +142,10 @@ export class EventDelegate {
         // hovering into nothing
         // hide if pop isn't pinned
         target.removeAttribute('unpinned-pop');
-        popEngine.hidePop(target, false);
+        let focusTrigger = new Trigger('focus');
+        if (!popEngine.isPopForTrigger(target, focusTrigger)) {
+          popEngine.hidePop(target, false);
+        }
         return;
       }
     }

--- a/src/MutationHandler/MutationHandler.spec.ts
+++ b/src/MutationHandler/MutationHandler.spec.ts
@@ -11,43 +11,6 @@ describe('MutationHandler - ', () => {
       mutationHandler.disconnectObserver();
     });
 
-    it('should call add to PopCache if addition to DOM', (done) => {
-
-      spyOn(popEngine, 'addPopToPopStore');
-      mutationHandler.registerObserver();
-
-      let el = document.createElement('div');
-      el.setAttribute('popgun', '');
-      el.setAttribute('id', 'test');
-      document.body.appendChild(el);
-
-      setTimeout(function(): void {
-        expect(popEngine.addPopToPopStore).toHaveBeenCalled();
-        document.body.removeChild(document.getElementById('test'));
-        done();
-      }, 0);
-
-    });
-
-    it('should call add to PopCache if popgun attr added to element', (done) => {
-
-      let el = document.createElement('div');
-      el.setAttribute('id', 'test');
-      document.body.appendChild(el);
-
-      spyOn(popEngine, 'addPopToPopStore');
-      mutationHandler.registerObserver();
-
-      document.getElementById('test').setAttribute('popgun', 'glomp');
-
-      setTimeout(function(): void {
-        expect(popEngine.addPopToPopStore).toHaveBeenCalled();
-        document.body.removeChild(document.getElementById('test'));
-        done();
-      }, 0);
-
-    });
-
     it('should not add to cache if element without popgun attr added to DOM', (done) => {
 
       spyOn(popEngine, 'addPopToPopStore');

--- a/src/Trigger/Trigger.spec.ts
+++ b/src/Trigger/Trigger.spec.ts
@@ -24,6 +24,10 @@ describe('Trigger - ', () => {
         expect((new Trigger('manual')).name).toBe(TriggerType.MANUAL);
     });
 
+    it('should set name to TriggerType.BLUR', () => {
+        expect((new Trigger('blur')).name).toBe(TriggerType.BLUR);
+    });
+
   });
 
   describe('TriggerEventType - ', () => {
@@ -44,6 +48,10 @@ describe('Trigger - ', () => {
           expect((new Trigger('manual')).eventType).toBe(TriggerEventType.MANUAL);
       });
 
+      it('should set focus event type to `focusout`', () => {
+          expect((new Trigger('blur')).eventType).toBe(TriggerEventType.BLUR);
+      });
+
   });
 
   describe('useCapture - ', () => {
@@ -62,6 +70,10 @@ describe('Trigger - ', () => {
 
       it('should be false for `manual`', () => {
           expect((new Trigger('manual')).useCapture).toBe(false);
+      });
+
+      it('should be false for `focusout`', () => {
+          expect((new Trigger('blur')).useCapture).toBe(false);
       });
 
   });

--- a/src/Trigger/index.ts
+++ b/src/Trigger/index.ts
@@ -27,11 +27,14 @@ export default class Trigger {
       case TriggerType.CLICK:
         this.eventType = TriggerEventType.CLICK;
         break;
-      case TriggerType.HOVER:
-        this.eventType = TriggerEventType.HOVER;
+      case TriggerType.BLUR:
+        this.eventType = TriggerEventType.BLUR;
         break;
       case TriggerType.FOCUS:
         this.eventType = TriggerEventType.FOCUS;
+        break;
+      case TriggerType.HOVER:
+        this.eventType = TriggerEventType.HOVER;
         break;
       case TriggerType.MANUAL:
         this.eventType = TriggerEventType.MANUAL;

--- a/src/TriggerEventType/TriggerEventType.spec.ts
+++ b/src/TriggerEventType/TriggerEventType.spec.ts
@@ -22,6 +22,10 @@ describe('TriggerEventType - ', () => {
       expect(TriggerEventType.MANUAL).toBe('popgun-manual');
     });
 
+    it('should set blur event type to `focusout`', () => {
+      expect(TriggerEventType.BLUR).toBe('focusout');
+    });
+
   });
 
   describe('triggerEventTypeToTriggerType - ', () => {
@@ -40,6 +44,10 @@ describe('TriggerEventType - ', () => {
 
     it('should return `manual` for `popgun-manual`', () => {
       expect(TriggerEventType.triggerEventTypeToTriggerType('popgun-manual')).toBe('manual');
+    });
+
+    it('should return `blur` for `focusout`', () => {
+      expect(TriggerEventType.triggerEventTypeToTriggerType('focusout')).toBe('blur');
     });
 
   });

--- a/src/TriggerEventType/index.ts
+++ b/src/TriggerEventType/index.ts
@@ -2,8 +2,9 @@ require('focusin').polyfill();
 
 export default class TriggerEventType {
   static CLICK: string = 'click';
-  static HOVER: string = 'mouseover';
+  static BLUR: string = 'focusout';
   static FOCUS: string = 'focusin';
+  static HOVER: string = 'mouseover';
   static MANUAL: string = 'popgun-manual';
   static MOUSEOUT: string = 'mouseout';
 
@@ -11,14 +12,17 @@ export default class TriggerEventType {
     switch (eventType) {
       case 'click':
         return 'click';
-      case 'mouseover':
-        return 'hover';
+      case 'focusout':
+        return 'blur';
       case 'focusin':
         return 'focus';
-      case 'popgun-manual':
-        return 'manual';
+      case 'mouseover':
+        return 'hover';
       case 'mouseout':
         return 'mouseout';
+      case 'popgun-manual':
+        return 'manual';
+      
     }
   }
 }

--- a/src/TriggerType/index.ts
+++ b/src/TriggerType/index.ts
@@ -1,7 +1,8 @@
 enum TriggerType {
   CLICK,
-  HOVER,
+  BLUR,
   FOCUS,
+  HOVER,
   MANUAL,
   MOUSEOUT
 }


### PR DESCRIPTION
- I used `focusout` rather than `blur` because of `focusout` has event bubbling. we also have the `focusin` polyfill which will take care of `focusin` and `focusout` in Firefox.
- I also removed some test cases that i forgot to remove from my last change to the mutation handler.