### PR TITLE
Renamed getPopFullChain to getPopChain and revise said function.

### DIFF
--- a/src/PopChainManager/index.ts
+++ b/src/PopChainManager/index.ts
@@ -8,13 +8,11 @@ export class PopChainManager {
     return closest(pop.targetEl, '[pop]', true);
   }
 
-  public getFullPopChain(pop: Pop, hideFullChain: boolean): Pop[] {
+  public getPopChain(pop: Pop, hideFullChain: boolean): Pop[] {
     let popChain: Pop[] = [];
 
     if (hideFullChain) {
       pop = this._getRootPop(pop);
-    } else {
-      pop = this._getFirstUnpinnedParentPop(pop);
     }
 
     let stack: Pop[] = [];

--- a/src/PopChainManager/index.ts
+++ b/src/PopChainManager/index.ts
@@ -13,6 +13,8 @@ export class PopChainManager {
 
     if (hideFullChain) {
       pop = this._getRootPop(pop);
+    } else {
+      pop = this._getFirstUnpinnedUnhoveredParentPop(pop);
     }
 
     let stack: Pop[] = [];
@@ -73,8 +75,8 @@ export class PopChainManager {
     }
   }
 
-  private _getFirstUnpinnedParentPop(pop: Pop): Pop {
-    while (!!pop.parentPop && !pop.parentPop.isPinned) {
+  private _getFirstUnpinnedUnhoveredParentPop(pop: Pop): Pop {
+    while (!!pop.parentPop && !pop.parentPop.isPinned && !pop.parentPop.popOver.element.querySelector(':hover')) {
       pop = pop.parentPop;
     }
     return pop;

--- a/src/PopEngine/index.ts
+++ b/src/PopEngine/index.ts
@@ -206,7 +206,7 @@ export class PopEngine {
     if (pop) {
       this.setState(pop, PopStateType.PRE_HIDE, pop.opts, null, false);
 
-      let popChain = popChainManager.getFullPopChain(pop, hideFullChain);
+      let popChain = popChainManager.getPopChain(pop, hideFullChain);
 
       popChain.forEach(function(p: Pop): void {
         popChainManager.removeParentChildRelationship(p);


### PR DESCRIPTION
When `getPopChain` does not need the full chain, it retrieves all pops starting from the farthest up  unpinned && unhovered pop.